### PR TITLE
Switches add-on base to Ubuntu

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -291,7 +291,7 @@ build:armhf:
   <<: *build
   variables:
     ADDON_ARCH: armhf
-    FROM: hassioaddons/base-armhf:2.0.1
+    FROM: hassioaddons/ubuntu-base-armhf:2.0.0
   tags:
     - build
     - armhf
@@ -300,7 +300,7 @@ build:aarch64:
   <<: *build
   variables:
     ADDON_ARCH: aarch64
-    FROM: hassioaddons/base-aarch64:2.0.1
+    FROM: hassioaddons/ubuntu-base-aarch64:2.0.0
   tags:
     - build
     - aarch64
@@ -309,7 +309,7 @@ build:i386:
   <<: *build
   variables:
     ADDON_ARCH: i386
-    FROM: hassioaddons/base-i386:2.0.1
+    FROM: hassioaddons/ubuntu-base-i386:2.0.0
   tags:
     - build
     - i386
@@ -318,7 +318,7 @@ build:amd64:
   <<: *build
   variables:
     ADDON_ARCH: amd64
-    FROM: hassioaddons/base-amd64:2.0.1
+    FROM: hassioaddons/ubuntu-base-amd64:2.0.0
   tags:
     - build
     - amd64

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -1,23 +1,21 @@
-ARG BUILD_FROM=hassioaddons/base:2.0.1
+ARG BUILD_FROM=hassioaddons/ubuntu-base-amd64:2.0.0
 # hadolint ignore=DL3006
 FROM ${BUILD_FROM}
 
-# Add env
-ENV TERM="xterm-256color"
-
 # Setup base
-# hadolint ignore=DL3003
+# hadolint ignore=DL3003,DL3008,SC2039
 RUN \
-    apk add --no-cache --virtual .build-dependencies \
-        alsa-lib-dev=1.1.6-r0 \
-        build-base=0.5-r1 \
-        cargo=1.26.2-r0 \
-        rust=1.26.2-r0 \
-        git=2.18.0-r0 \
-        libressl-dev=2.7.4-r0 \
+    apt-get update \
     \
-    && apk add --no-cache \
-        alsa-lib=1.1.6-r0 \
+    && apt-get install -y --no-install-recommends \
+        cargo \
+        git \
+        libasound2-dev \
+        lubasound2 \
+        libssl-dev \
+        rustc \
+        build-essential \
+        pkg-config \
     \
     && git clone --branch "v0.2.2" --depth=1 \
         https://github.com/Spotifyd/spotifyd.git /tmp/spotifyd \
@@ -26,8 +24,19 @@ RUN \
     && cargo build --release \
     && mv /tmp/spotifyd/target/release/spotifyd /usr/bin \
     \
+    && apt-get purge -y --auto-remove \
+        cargo \
+        git \
+        libasound2-dev \
+        libssl-dev \
+        rustc \
+        build-essential \
+        pkg-config \
+    \
     && rm -f -r /tmp/* \
-    && apk del --purge .build-dependencies
+    && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /var/lib/{apt,dpkg,cache,log}/* \
+    && rm -rf /var/{cache,log}/*/*
 
 # Copy root filesystem
 COPY rootfs /

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -11,7 +11,7 @@ RUN \
         cargo \
         git \
         libasound2-dev \
-        lubasound2 \
+        libasound2 \
         libssl-dev \
         rustc \
         build-essential \

--- a/spotify/build.json
+++ b/spotify/build.json
@@ -1,10 +1,9 @@
 {
-    "squash": false,
     "build_from": {
-        "aarch64": "hassioaddons/base-aarch64:2.0.1",
-        "amd64": "hassioaddons/base-amd64:2.0.1",
-        "armhf": "hassioaddons/base-armhf:2.0.1",
-        "i386": "hassioaddons/base-i386:2.0.1"
+        "aarch64": "hassioaddons/ubuntu-base-aarch64:2.0.0",
+        "amd64": "hassioaddons/ubuntu-base-amd64:2.0.0",
+        "armhf": "hassioaddons/ubuntu-base-armhf:2.0.0",
+        "i386": "hassioaddons/ubuntu-base-i386:2.0.0"
     },
     "args": {}
 }


### PR DESCRIPTION
# Proposed Changes

Currently, the add-on was set to use Alpine Linux.
Alpine uses Musllib and it is hard to get the Spotify daemon compiled with it for all architecture that Hass.io supports. Therefore, switching to Ubuntu.

## Related Issues

None