### PR TITLE
Clarify ARMv6 is not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Valid values: `96`, `160` (default) or `320`.
 
 ## Known issues and limitations
 
+- This add-on does support ARM-based devices, nevertheless, they must
+  at least be an ARMv7 device. (Raspberry Pi 1 and Zero is not supported).
 - This add-on requires a Spotify Premium account.
 
 ## Changelog & Releases


### PR DESCRIPTION
# Proposed Changes

Add the limitation about raspi 1 and 0 to the readme.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/