### PR TITLE
📚 Connect doesn't require a premium account anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ to do is hook up your sound system to the Pi and start booming!
 
 ## Installation
 
-**IMPORTANT**: _This add-on requires a Spotify Premium account!_
-
 The installation of this add-on is pretty straightforward and not different in
 comparison to installing any other Hass.io add-on.
 


### PR DESCRIPTION
# Proposed Changes

Spotify Connect doesn't require a premium account anymore to use it.
You can read about it e.g. [here](https://www.theverge.com/2018/11/7/18071464/spotify-connect-free-tier-ad-supported-premium).

## Related Issues

None.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/