### PR TITLE
Use status_entity option for instantaneous entity update

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -33,6 +33,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+status_entity: sensor.spotify_connect
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -85,6 +86,12 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `status_entity`
+
+The `status_entity` is optional and allows the add-on to update its status to a Home Assistant entity.
+
+This is helpful for automations requiring immediate Spotify status - something that the Spotify integration can't do because it uses pooling method.
 
 ## Known issues and limitations
 

--- a/spotify/config.json
+++ b/spotify/config.json
@@ -10,6 +10,7 @@
   "boot": "auto",
   "hassio_api": true,
   "hassio_role": "default",
+  "homeassistant_api": true,
   "host_network": true,
   "audio": true,
   "options": {
@@ -20,6 +21,7 @@
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "username": "str?",
     "password": "password?",
+    "status_entity": "str?",
     "name": "match(^[A-Za-z0-9-.]+$)?",
     "bitrate": "list(96|160|320)"
   }

--- a/spotify/rootfs/etc/cont-init.d/spotifyd.sh
+++ b/spotify/rootfs/etc/cont-init.d/spotifyd.sh
@@ -36,3 +36,13 @@ bitrate=$(bashio::config 'bitrate')
     echo "device_name =${name}"
     echo "bitrate =${bitrate}"
 } >> /etc/spotifyd.conf
+
+if bashio::config.has_value 'status_entity'; then
+    status_entity=$(bashio::config 'status_entity')
+    echo "on_song_change_hook = /usr/bin/song_change_hook.sh" >> /etc/spotifyd.conf
+    {
+        echo "#!/bin/bash"
+        echo "curl -X POST -H \"Authorization: Bearer \${SUPERVISOR_TOKEN}\" -H \"Content-Type: application/json\" -d \"{\\\"state\\\": \\\"\$PLAYER_EVENT\\\", \\\"attributes\\\": {\\\"track_id\\\": \\\"\$TRACK_ID\\\"}}\" http://supervisor/core/api/states/${status_entity}"
+    } > /usr/bin/song_change_hook.sh
+    exec chmod a+x /usr/bin/song_change_hook.sh
+fi


### PR DESCRIPTION
# Proposed Changes

Add a new status_entity option that updates the corresponding Home Assistant entity immediately when status changes. This is helpful for automations requiring immediate Spotify status - something that the Spotify integration can't do because it uses pooling method.

## Related Issues

https://github.com/home-assistant/core/pull/21391