### PR TITLE
Use `cargo install`

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -31,7 +31,9 @@ RUN \
     && apk del --no-cache --purge .build-dependencies \
     && rm -fr \
         /tmp/* \
-        ~/.cargo
+        ~/.cargo \
+        /usr/.crates.toml \
+        /usr/.crates2.json
 
 # Copy root filesystem
 COPY rootfs /

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -18,30 +18,19 @@ RUN \
     && apk add --no-cache \
         pulseaudio=14.1-r0 \
     \
-    && curl -J -L -o /tmp/librespot.tar.gz \
-        "https://github.com/librespot-org/librespot/archive/v0.2.0.tar.gz" \
-    \
-    && mkdir -p /usr/src/local/librespot \
-    && tar zxvf \
-        /tmp/librespot.tar.gz \
-        --strip 1 -C /usr/src/local/librespot \
-    \
-    && export RUSTFLAGS="-C target-feature=-crt-static" \
-    && export CARGO_NET_GIT_FETCH_WITH_CLI="true" \
-    \
-    && cd /usr/src/local/librespot \
-    && cargo build \
+    && cargo install \
+        --locked \
         --no-default-features \
         --features pulseaudio-backend \
-        --release \
+        --root /usr \
+        --bin librespot \
+        --version 0.2.0 \
         --verbose \ 
-    \
-    && mv target/release/librespot /usr/bin/librespot \
+        -- librespot \
     \
     && apk del --no-cache --purge .build-dependencies \
     && rm -fr \
         /tmp/* \
-        /usr/src/local/librespot \
         ~/.cargo
 
 # Copy root filesystem


### PR DESCRIPTION
# Proposed Changes

Simplify the build process by using the `librespot` version published on crates.io

Still unsure about L29-L30 - as I'm using the upstream build configuration, I don't feel like fiddling with build arguments. If there's a good reason for those parameters to be there (and I can't find one - this works on my test environment), I can re-add them.