### PR TITLE
Add volume control configuration options

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -70,6 +70,18 @@ however, the add-on consumes more data.
 
 Valid values: `96`, `160` (default) or `320`.
 
+### Option: `initial_volume`
+
+The initial volume Spotify should be set to.
+
+Valid values: any integer value between `0` and `100` (default).
+
+### Option: `volume_scaling`
+
+The type of scale used by the volume slider.
+
+Valid values: `log` (default), `linear` or `fixed`.
+
 ### Option: `username`
 
 **IMPORTANT**: _This requires a Spotify Premium account!_

--- a/spotify/config.json
+++ b/spotify/config.json
@@ -9,12 +9,16 @@
   "audio": true,
   "options": {
     "name": "Home Assistant",
-    "bitrate": 160
+    "bitrate": 160,
+    "initial_volume": 100,
+    "volume_scaling": "log"
   },
   "schema": {
     "log_level": "list(trace|debug|info|notice|warning|error|fatal)?",
     "name": "str",
     "bitrate": "list(96|160|320)",
+    "initial_volume": "int(0,100)?",
+    "volume_scaling": "list(linear|log|fixed)?",
     "username": "str?",
     "password": "password?"
   }

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -14,6 +14,12 @@ bashio::log.info 'Starting the Spotify daemon...'
 # Bitrate
 options+=(--bitrate $(bashio::config 'bitrate'))
 
+# Initial volume
+options+=(--initial-volume $(bashio::config 'initial_volume'))
+
+# Volume scaling
+options+=(--volume-ctrl $(bashio::config 'volume_scaling'))
+
 # Device name
 name=$(bashio::config 'name')
 options+=(--name "${name}")

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -14,6 +14,15 @@ configuration:
     description: >-
       The bitrate Spotify should use. The higher, the better the sound quality,
       however, the add-on consumes more data.
+  initial_volume:
+    name: Initial volume
+    description: >-
+      The initial volume Spotify should be set to (0-100).
+  volume_scaling:
+    name: Volume scaling
+    description: >-
+      The type of scale used by the volume slider. Choose between logarithmic (default),
+      linear, or fixed.
   username:
     name: Spotify username
     description: >-


### PR DESCRIPTION
# Proposed Changes

Add configuration options to make the volume behaviour more configurable:

- Initial volume, to prevent accidental high-volume music blasting
- Volume scaling, to allow finer control at higher volumes