### PR TITLE
🚀 Add-on CI improvements

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -132,11 +132,9 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: /tmp/.docker-cache
-          key:
-            docker-${{ github.ref }}-${{ matrix.architecture }}-${{ github.sha
-            }}
+          key: docker-${{ matrix.architecture }}-${{ github.sha }}
           restore-keys: |
-            docker-${{ github.ref }}-${{ matrix.architecture }}
+            docker-${{ matrix.architecture }}
       - name: 🏗 Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
       - name: 🏗 Set up Docker Buildx
@@ -186,7 +184,7 @@ jobs:
           cache-from: |
             type=local,src=/tmp/.docker-cache
             ghcr.io/hassio-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
-          cache-to: type=local,mode=max,dest=/tmp/.docker-cache
+          cache-to: type=local,mode=max,dest=/tmp/.docker-cache-new
           platforms: ${{ steps.flags.outputs.platform }}
           build-args: |
             BUILD_ARCH=${{ matrix.architecture }}
@@ -197,3 +195,11 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=edge
+      # This ugly bit is necessary, or our cache will grow forever...
+      # Well until we hit GitHub's limit of 5GB :)
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: 🚚 Swap build cache
+        run: |
+          rm -rf /tmp/.docker-cache
+          mv /tmp/.docker-cache-new /tmp/.docker-cache

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -75,11 +75,9 @@ jobs:
         uses: actions/cache@v2.1.6
         with:
           path: /tmp/.docker-cache
-          key:
-            docker-${{ github.ref }}-${{ matrix.architecture }}-${{ github.sha
-            }}
+          key: docker-${{ matrix.architecture }}-${{ github.sha }}
           restore-keys: |
-            docker-${{ github.ref }}-${{ matrix.architecture }}
+            docker-${{ matrix.architecture }}
       - name: 🏗 Set up QEMU
         uses: docker/setup-qemu-action@v1.2.0
       - name: 🏗 Set up Docker Buildx
@@ -140,7 +138,7 @@ jobs:
           cache-from: |
             type=local,src=/tmp/.docker-cache
             ghcr.io/hassio-addons/${{ needs.information.outputs.slug }}/${{ matrix.architecture }}:edge
-          cache-to: type=local,mode=max,dest=/tmp/.docker-cache
+          cache-to: type=local,mode=max,dest=/tmp/.docker-cache-new
           platforms: ${{ steps.flags.outputs.platform }}
           build-args: |
             BUILD_ARCH=${{ matrix.architecture }}
@@ -151,6 +149,14 @@ jobs:
             BUILD_REF=${{ github.sha }}
             BUILD_REPOSITORY=${{ github.repository }}
             BUILD_VERSION=${{ needs.information.outputs.version }}
+      # This ugly bit is necessary, or our cache will grow forever...
+      # Well until we hit GitHub's limit of 5GB :)
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: 🚚 Swap build cache
+        run: |
+          rm -rf /tmp/.docker-cache
+          mv /tmp/.docker-cache-new /tmp/.docker-cache
       - name: 🔏 Notarize
         # yamllint disable rule:line-length
         run: |

--- a/.github/workflows/pr-labels.yaml
+++ b/.github/workflows/pr-labels.yaml
@@ -3,7 +3,7 @@ name: PR Labels
 
 # yamllint disable-line rule:truthy
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, labeled, unlabeled, synchronize]
 
 jobs:
@@ -14,6 +14,7 @@ jobs:
       - name: 🏷 Verify PR has a valid label
         uses: jesusvasquez333/verify-pr-label-action@v1.4.0
         with:
+          pull-request-number: "${{ github.event.pull_request.number }}"
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           valid-labels: >-
             breaking-change, bugfix, documentation, enhancement, refactor,


### PR DESCRIPTION
# Proposed Changes

A couple of CI improvements for the Community add-ons.

- Docker build cache restored from GitHub, no longer takes the ref into account, this allows re-use of the cache in more cases. Lets Docker figures it out (which is what our Dockerfiles are optimized for).
- Applied the same to the deploy, allowing the deploy to use the same cache from the CI.
- Prevents GitHub cache artifacts to grow forever. This is a known issue, however, this PR applies a workaround.
- Fix applied to the label checker, to ensure it works for forked repositories as well.
