### PR TITLE
Add autoplay option to addon

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -37,6 +37,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+autoplay: true
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -87,6 +88,10 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `autoplay`
+
+Whether Spotify should autoplay similar songs when reaching the end of the queue.
 
 ## Known issues and limitations
 

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -22,3 +22,4 @@ schema:
   bitrate: list(96|160|320)
   username: str?
   password: password?
+  autoplay: bool

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -8,6 +8,7 @@ declare bitrate
 declare name
 declare password
 declare username
+declare autoplay
 
 bashio::log.info 'Starting the Spotify daemon...'
 
@@ -31,6 +32,11 @@ fi
 
 # Save writes
 options+=(--disable-audio-cache)
+
+# Toggle autoplay
+if bashio::config.true 'autoplay'; then
+  options+=(--verbose)
+fi
 
 # Are we running in debug mode?
 if bashio::debug; then

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -23,3 +23,8 @@ configuration:
     name: Spotify password
     description: >-
       The password to log into your Spotify Premium account with.
+  autoplay:
+    name: Autoplay
+    description: >-
+      Whether Spotify should autoplay similar songs at the end of the queue.
+


### PR DESCRIPTION
# Proposed Changes

Librespot has the option to enable autoplay. Autoplay plays related songs at the end of the queue, similar to what has been playing. This change adds an option to the addon's settings to enable autoplay. 

## Related Issues

_No related existing issues as far as I am aware_