### PR TITLE
Add librespot autoplay option

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -37,6 +37,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+autoplay: true
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -87,6 +88,10 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `autoplay`
+
+Whether Spotify should autoplay similar songs when reaching the end of the queue.
 
 ## Known issues and limitations
 

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -15,7 +15,6 @@ init: false
 options:
   name: Home Assistant
   bitrate: 160
-  autoplay: true
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -15,9 +15,11 @@ init: false
 options:
   name: Home Assistant
   bitrate: 160
+  autoplay: true
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str
   bitrate: list(96|160|320)
   username: str?
   password: password?
+  autoplay: bool

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -8,6 +8,7 @@ declare bitrate
 declare name
 declare password
 declare username
+declare autoplay
 
 bashio::log.info 'Starting the Spotify daemon...'
 
@@ -27,6 +28,11 @@ if bashio::config.has_value 'username'; then
 
     options+=(--username "${username}")
     options+=(--password "${password}")
+fi
+
+# Autoplay
+if bashio::config.true 'autoplay'; then
+  options+=(--autoplay)
 fi
 
 # Save writes

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -23,3 +23,7 @@ configuration:
     name: Spotify password
     description: >-
       The password to log into your Spotify Premium account with.
+  autoplay:
+    name: Autoplay
+    description: >-
+      Whether Spotify should autoplay similar songs at the end of the queue.


### PR DESCRIPTION
# Proposed Changes

The Spotify connect addon currently does not support autoplay functionality, meaning it can't keep playing after a song/playlist is over. This PR adds this as an option.
Note that librespot autoplay is also quite unreliable at the moment (i.e. it does not work with singular songs), but it's the best we're getting until 0.5.0



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an autoplay option for Spotify Connect, allowing automatic playback of similar songs when the queue ends.

- **Documentation**
	- Updated configuration examples and help texts to guide users on enabling and using the new autoplay feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->