### PR TITLE
Add `initial_volume` option

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -37,6 +37,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+initial_volume: 90
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -87,6 +88,10 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `initial_volume`
+
+The initial volume in % from 0-100.
 
 ## Known issues and limitations
 

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -21,3 +21,4 @@ schema:
   bitrate: list(96|160|320)
   username: str?
   password: password?
+  initial_volume: int(0,100)?

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -29,6 +29,11 @@ if bashio::config.has_value 'username'; then
     options+=(--password "${password}")
 fi
 
+# Initial volume
+if bashio::config.has_value 'initial_volume'; then
+  options+=(--initial-volume $(bashio::config 'initial_volume'))
+fi
+
 # Save writes
 options+=(--disable-audio-cache)
 

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -23,3 +23,7 @@ configuration:
     name: Spotify password
     description: >-
       The password to log into your Spotify Premium account with.
+  initial_volume:
+    name: Initial volume
+    description: >-
+      The initial volume in % from 0-100.


### PR DESCRIPTION
This PR adds support for changing the default volume. It's completely opt-in and does not change any existing behaviour

Currently the default is at 90% volume. While I appreciate my speakers' ability to be loud, I wanted to be able to default to a more sensible volume.

See the [librespot documentation](https://github.com/librespot-org/librespot/wiki/Options#:~:text=Option-,initial%2Dvolume,-Initial%20volume%20in) for more information on how `initial-volume` works

---

To test this option:

1. Change the value in the config, e.g. `50` (50%)
1. Save changes & restart the addon
a. If the log level is debug, see that `initial-volume` is present in the `Command line argument(s)` section
1. Connect to Home Assistant from another device, see that the volume is 50%

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new setting to configure the initial volume for Spotify integration, allowing users to set the volume from 0-100%.
  - Updated documentation to include instructions for the new `initial_volume` configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->