### PR TITLE
Add `enable_volume_normalisation` option

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -37,6 +37,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+enable_volume_normalisation: false
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -87,6 +88,10 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `enable_volume_normalisation`
+
+Whether to enable volume normalisation. For more info see the [librespot documentation][librespot-volume-normalisation].
 
 ## Known issues and limitations
 
@@ -159,6 +164,7 @@ SOFTWARE.
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-spotify-connect/61210?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/addon-spotify-connect/issues
+[librespot-volume-normalisation]: https://github.com/librespot-org/librespot/wiki/Options#volume-normalisation
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-spotify-connect/releases
 [semver]: http://semver.org/spec/v2.0.0.htm

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -21,3 +21,4 @@ schema:
   bitrate: list(96|160|320)
   username: str?
   password: password?
+  enable_volume_normalisation: bool?

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -29,6 +29,11 @@ if bashio::config.has_value 'username'; then
     options+=(--password "${password}")
 fi
 
+# Volume Normalisation
+if bashio::config.true 'enable_volume_normalisation'; then
+  options+=(--enable-volume-normalisation)
+fi
+
 # Save writes
 options+=(--disable-audio-cache)
 

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -23,3 +23,7 @@ configuration:
     name: Spotify password
     description: >-
       The password to log into your Spotify Premium account with.
+  enable_volume_normalisation:
+    name: Enable volume normalisation
+    description: >-
+      Whether to enable volume normalisation.


### PR DESCRIPTION
This PR adds support for enabling volume normalisation. It's completely opt-in and does not change any existing behaviour

Currently volume normalisation is disabled and cannot be enabled. Some songs play at significantly different volumes and normalisation makes these tracks approximately the same volume (at the cost of a minor decrease in audio quality)

See the [librespot documentation](https://github.com/librespot-org/librespot/wiki/Options#volume-normalisation) for more information on how `enable-volume-normalisation` works

---

To test this option:

1. With volume normalisation disabled, play [It's Time by Gavin Mikhail](https://open.spotify.com/track/67jTooF4NM8NkbmzDoVbKY?si=ddf147af3cc04659) and then [I See Fire by Ed Sheeran](https://open.spotify.com/track/5pY3ovFxbvAg7reGZjJQSp?si=eb53a6978e704825)
1. Hear that one is much louder than the other
1. Enable volume normalisation
1. Save changes & restart the addon
a. If the log level is debug, see that `enable-volume-normalisation` is present in the `Command line argument(s)` section
1. Play the songs again, hear that they are closer to the same volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration option `enable_volume_normalisation` for Spotify, allowing users to normalize volume levels.
- **Documentation**
  - Updated documentation to include details about the new `enable_volume_normalisation` option.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->