### PR TITLE
Add `librespot_options` option

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -37,6 +37,7 @@ name: HomeAssistant
 bitrate: 320
 username: frenck@example.com
 password: MySpotifyPassword
+librespot_options: --volume-ctrl fixed --normalisation-pregain -9
 ```
 
 **Note**: _This is just an example, don't copy and paste it! Create your own!_
@@ -87,6 +88,10 @@ to disallow guests on your network to use the add-on.
 ### Option: `password`
 
 The password you use to login to your Spotify Premium account.
+
+### Option: `librespot_options`
+
+Additional options for librespot. For more info see the [librespot documentation][librespot-options].
 
 ## Known issues and limitations
 
@@ -159,6 +164,7 @@ SOFTWARE.
 [forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-spotify-connect/61210?u=frenck
 [frenck]: https://github.com/frenck
 [issue]: https://github.com/hassio-addons/addon-spotify-connect/issues
+[librespot-options]: https://github.com/librespot-org/librespot/wiki/Options
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/addon-spotify-connect/releases
 [semver]: http://semver.org/spec/v2.0.0.htm

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -21,3 +21,4 @@ schema:
   bitrate: list(96|160|320)
   username: str?
   password: password?
+  librespot_options: str?

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -8,6 +8,7 @@ declare bitrate
 declare name
 declare password
 declare username
+declare librespot_options
 
 bashio::log.info 'Starting the Spotify daemon...'
 
@@ -37,5 +38,11 @@ if bashio::debug; then
   options+=(--verbose)
 fi
 
+# Additional command line options
+librespot_options=''
+if bashio::config.has_value 'librespot_options'; then
+    librespot_options="$(bashio::config 'librespot_options')"
+fi
+
 # Run librespot
-exec librespot "${options[@]}"
+exec librespot "${options[@]}" $librespot_options

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -23,3 +23,8 @@ configuration:
     name: Spotify password
     description: >-
       The password to log into your Spotify Premium account with.
+  librespot_options:
+    name: Librespot options
+    description: >-
+      Additional options for librespot. For available options see:
+      https://github.com/librespot-org/librespot/wiki/Options.


### PR DESCRIPTION
This PR adds support for adding arbitrary additional librespot options. It's completely opt-in and does not change any existing behaviour

Some users may wish to change librespot settings, and many won't have the time to fluff around cloning repos and adding options to suit their use case. This is a minimal effort way to enable advanced users to use any option in while using the addon.

See the [librespot documentation](https://github.com/librespot-org/librespot/wiki/Options) for more information about other options

---

To test this option:

1. Enable debug logging; we'll check that the settings are being correctly set by reading the logs
1. Change the value in the config, e.g. `--volume-ctrl fixed --normalisation-pregain -9`
1. Save changes & restart the addon
1. View the logs, see sample output below

<details>
<summary>Sample output</summary>

```
[2024-04-06T12:31:32Z INFO  librespot] librespot 0.4.2 UNKNOWN (Built on 2024-04-01, Build ID: YwHEteUz, Profile: release)
[2024-04-06T12:31:32Z TRACE librespot] Command line argument(s):
[2024-04-06T12:31:32Z TRACE librespot] 		bitrate "320"
[2024-04-06T12:31:32Z TRACE librespot] 		name "Home Assistant"
[2024-04-06T12:31:32Z TRACE librespot] 		disable-audio-cache
[2024-04-06T12:31:32Z TRACE librespot] 		verbose
[2024-04-06T12:31:32Z TRACE librespot] 		volume-ctrl "fixed"
[2024-04-06T12:31:32Z TRACE librespot] 		normalisation-pregain "-9"
[2024-04-06T12:31:32Z DEBUG librespot_discovery::server] Zeroconf server listening on 0.0.0.0:43321
```

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration option, `librespot_options`, allowing users to specify additional parameters for the Librespot service in HomeAssistant.
	- Updated documentation to include details about the `librespot_options` for better user awareness and guidance.

- **Enhancements**
	- Improved flexibility in the Spotify daemon’s startup configuration by allowing more customizable command-line options.

- **Translations**
	- Added new entries in the translation files to inform users about the `librespot_options` feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->