### PR TITLE
Fix problem with declaring bash variable with dash

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -35,7 +35,7 @@ Example add-on configuration:
 log_level: info
 name: HomeAssistant
 bitrate: 320
-initial-volume: 50
+initial_volume: 50
 username: frenck@example.com
 password: MySpotifyPassword
 autoplay: true
@@ -76,12 +76,12 @@ however, the add-on consumes more data.
 
 Valid values: `96`, `160` (default) or `320`.
 
-### Option: `initial-volume`
+### Option: `initial_volume`
 
 Initial volume in % from 0-100. This setting takes effect when the addon starts or
 recovers from a crash.
 
-initial-volume: 50 # Optional
+initial_volume: 50 # Optional
 
 ### Option: `username`
 

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -15,7 +15,7 @@ init: false
 options:
   name: Home Assistant
   bitrate: 160
-  initial-volume: 50
+  initial_volume: 50
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str
@@ -23,4 +23,4 @@ schema:
   username: str?
   password: password?
   autoplay: bool
-  initial-volume: match(^([0-9]|[1-9][0-9]|100)$)?
+  initial_volume: match(^([0-9]|[1-9][0-9]|100)$)?

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -17,9 +17,9 @@ bashio::log.info 'Starting the Spotify daemon...'
 options+=(--bitrate $(bashio::config 'bitrate'))
 
 # Initial Volume
-initial_volume=$(bashio::config 'initial-volume')
+initial_volume=$(bashio::config 'initial_volume')
 if ! [[ "$initial_volume" =~ ^[0-9]+$ ]] || [ "$initial_volume" -lt 0 ] || [ "$initial_volume" -gt 100 ]; then
-    bashio::log.warning "Invalid initial-volume value: $initial_volume. Using default."
+    bashio::log.warning "Invalid initial_volume value: $initial_volume. Using default."
     initial_volume=50
 fi
 options+=(--initial-volume "$initial_volume")

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -9,7 +9,7 @@ declare name
 declare password
 declare username
 declare autoplay
-declare initial-volume
+declare initial_volume
 
 bashio::log.info 'Starting the Spotify daemon...'
 
@@ -23,7 +23,6 @@ if ! [[ "$initial_volume" =~ ^[0-9]+$ ]] || [ "$initial_volume" -lt 0 ] || [ "$i
     initial_volume=50
 fi
 options+=(--initial-volume "$initial_volume")
-
 
 # Device name
 name=$(bashio::config 'name')

--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -14,7 +14,7 @@ configuration:
     description: >-
       The bitrate Spotify should use. The higher, the better the sound quality,
       however, the add-on consumes more data.
-  initial-volume:
+  initial_volume:
     name: Initial Volume
     description: >-
       Initial volume in % from 0-100.

--- a/spotify/translations/hu.yaml
+++ b/spotify/translations/hu.yaml
@@ -14,7 +14,7 @@ configuration:
     description: >-
       A Spotify által használt bitráta beállítása. Minél magasabb, annál jobb
       minőségű, viszont ez nagyobb adatforgalommal jár.
-  initial-volume:
+  initial_volume:
     name: Kezdeti térfogat
     description: >-
       Kezdeti térfogat %-ban 0-100 között.

--- a/spotify/translations/it.yaml
+++ b/spotify/translations/it.yaml
@@ -14,7 +14,7 @@ configuration:
     description: >-
       Il bitrate che Spotify dovrebbe usare. Piú é alto, migliore é la qualitá sonora,
       tuttavia, l'add-on consumerá piú banda.
-  initial-volume:
+  initial_volume:
     name: Volume Iniziale
     description: >-
       Volume iniziale in % da 0 a 100.


### PR DESCRIPTION
# Proposed Changes

![image](https://github.com/user-attachments/assets/4a9648fd-5dd3-4a98-9778-83f32914ca40)
This happens because variables in bash cannot have dash (-) in their name (afaik). This PR fixes it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Revised the user documentation to reflect the updated naming convention for the initial volume setting.
  
- **Chore**
  - Renamed the initial volume configuration option from a hyphenated form to snake_case across all user-facing configuration references, ensuring improved consistency with standard YAML practices without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->