### PR TITLE
Remove unneeded volume checks

### DIFF
--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -16,6 +16,7 @@ options:
   name: Home Assistant
   bitrate: 160
   initial_volume: 50
+  autoplay: true
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -18,10 +18,6 @@ options+=(--bitrate $(bashio::config 'bitrate'))
 
 # Initial Volume
 initial_volume=$(bashio::config 'initial_volume')
-if ! [[ "$initial_volume" =~ ^[0-9]+$ ]] || [ "$initial_volume" -lt 0 ] || [ "$initial_volume" -gt 100 ]; then
-    bashio::log.warning "Invalid initial_volume value: $initial_volume. Using default."
-    initial_volume=50
-fi
 options+=(--initial-volume "$initial_volume")
 
 # Device name


### PR DESCRIPTION
# Proposed Changes

The validation of the volume is already performed by the Supervisor, cleaning up the one in the case base for that reason.

../Frenck

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced an autoplay option for Spotify Connect so that playback begins automatically.

- **Chores**
  - Updated the handling of initial volume settings to streamline how user-defined volume preferences are applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->