### PR TITLE
Update librespot 0.7.0

### DIFF
--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -6,7 +6,7 @@ FROM ${BUILD_FROM}
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Setup base
-ARG LIBRESPOT_VERSION="0.6.0"
+ARG LIBRESPOT_VERSION="0.7.0"
 # hadolint ignore=DL3003
 RUN \
     apk add --no-cache --virtual .build-dependencies \

--- a/spotify/Dockerfile
+++ b/spotify/Dockerfile
@@ -9,7 +9,11 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG LIBRESPOT_VERSION="0.7.0"
 # hadolint ignore=DL3003
 RUN \
-    apk add --no-cache --virtual .build-dependencies \
+    apk add --no-cache \
+        libssl3=3.5.2-r0 \
+        libcrypto3=3.5.2-r0 \
+    \
+    && apk add --no-cache --virtual .build-dependencies \
         build-base=0.5-r3 \
         cargo=1.87.0-r0 \
         git=2.49.1-r0 \
@@ -17,6 +21,7 @@ RUN \
         pulseaudio-dev=17.0-r5 \
         cmake=3.31.7-r1 \
         clang19-libclang=19.1.7-r6 \
+        openssl-dev=3.5.2-r0 \
     \
     && apk add --no-cache \
         pulseaudio=17.0-r5 \
@@ -26,11 +31,11 @@ RUN \
     && cargo install \
         --locked \
         --no-default-features \
-        --features "pulseaudio-backend with-libmdns" \
+        --features "native-tls pulseaudio-backend with-libmdns" \
         --root /usr \
         --bin librespot \
         --version "${LIBRESPOT_VERSION}" \
-        --verbose \ 
+        --verbose \
         -- librespot \
     \
     && cargo uninstall bindgen-cli \


### PR DESCRIPTION
# Proposed Changes

Updates librespot to 0.7.0, adds new `native-tls` feature and libressl-dev dependency.

## Related Issues

https://github.com/hassio-addons/addon-spotify-connect/issues/308
https://github.com/hassio-addons/addon-spotify-connect/issues/309
https://github.com/hassio-addons/addon-spotify-connect/issues/310


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled native TLS support for the Spotify backend.

* **Chores**
  * Upgraded the bundled librespot component to v0.7.0.
  * Added required SSL libraries and build dependencies for the updated stack.
  * Adjusted build features for the audio backend to align with the new librespot release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->