### PR TITLE
Drop support for armv7 systems

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,7 @@
       "matchStringsStrategy": "any",
       "matchStrings": [
         "ARG BUILD_FROM=(?<depName>.*?):(?<currentValue>.*?)\\s+",
-        "(aarch64|amd64|armhf|armv7|i386):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
+        "(aarch64|amd64):\\s[\"']?(?<depName>.*?):(?<currentValue>.*?)[\"']?\\s"
       ],
       "datasourceTemplate": "docker"
     },

--- a/README.md
+++ b/README.md
@@ -4,11 +4,8 @@
 ![Project Stage][project-stage-shield]
 [![License][license-shield]](LICENSE.md)
 
-![Supports armhf Architecture][armhf-shield]
-![Supports armv7 Architecture][armv7-shield]
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
-![Supports i386 Architecture][i386-shield]
 
 [![Github Actions][github-actions-shield]][github-actions]
 ![Project Maintenance][maintenance-shield]
@@ -103,8 +100,6 @@ SOFTWARE.
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg
-[armhf-shield]: https://img.shields.io/badge/armhf-no-red.svg
-[armv7-shield]: https://img.shields.io/badge/armv7-yes-green.svg
 [commits-shield]: https://img.shields.io/github/commit-activity/y/hassio-addons/addon-spotify-connect.svg
 [commits]: https://github.com/hassio-addons/addon-spotify-connect/commits/main
 [contributors]: https://github.com/hassio-addons/addon-spotify-connect/graphs/contributors
@@ -119,7 +114,6 @@ SOFTWARE.
 [github-actions]: https://github.com/hassio-addons/addon-spotify-connect/actions
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
-[i386-shield]: https://img.shields.io/badge/i386-no-red.svg
 [issue]: https://github.com/hassio-addons/addon-spotify-connect/issues
 [license-shield]: https://img.shields.io/github/license/hassio-addons/addon-spotify-connect.svg
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2025.svg

--- a/spotify/build.yaml
+++ b/spotify/build.yaml
@@ -2,4 +2,3 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/base:18.2.1
   amd64: ghcr.io/hassio-addons/base:18.2.1
-  armv7: ghcr.io/hassio-addons/base:18.2.1

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -7,7 +7,6 @@ url: https://github.com/hassio-addons/addon-spotify-connect
 arch:
   - aarch64
   - amd64
-  - armv7
 host_network: true
 audio: true
 init: false


### PR DESCRIPTION
# Proposed Changes

The Home Assistant project has deprecated the armv7 architecture, and it is being dropped full in the Home Assistant 2025.12 release. This PR drops armv7 support from this add-on.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discontinued support for armhf, armv7, and i386 architectures. The application now runs exclusively on aarch64 and amd64 platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->