### PR TITLE
Remove non-functional username/password login

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -36,8 +36,6 @@ log_level: info
 name: HomeAssistant
 bitrate: 320
 initial_volume: 50
-username: frenck@example.com
-password: MySpotifyPassword
 autoplay: true
 ```
 
@@ -82,20 +80,6 @@ Initial volume in % from 0-100. This setting takes effect when the app starts or
 recovers from a crash.
 
 initial_volume: 50 # Optional
-
-### Option: `username`
-
-**IMPORTANT**: _This requires a Spotify Premium account!_
-
-The username you use to login to your Spotify Premium account. Setting
-this will bind the app to your account exclusively.
-
-This can be helpful when experiencing discovery issues on your network or
-to disallow guests on your network to use the app.
-
-### Option: `password`
-
-The password you use to login to your Spotify Premium account.
 
 ### Option: `autoplay`
 

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -19,7 +19,5 @@ schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str
   bitrate: list(96|160|320)
-  username: str?
-  password: password?
   autoplay: bool
   initial_volume: match(^([0-9]|[1-9][0-9]|100)$)?

--- a/spotify/rootfs/etc/services.d/spotifyd/run
+++ b/spotify/rootfs/etc/services.d/spotifyd/run
@@ -6,8 +6,6 @@
 declare -a options
 declare bitrate
 declare name
-declare password
-declare username
 declare autoplay
 declare initial_volume
 
@@ -23,17 +21,6 @@ options+=(--initial-volume "$initial_volume")
 # Device name
 name=$(bashio::config 'name')
 options+=(--name "${name}")
-
-# Username / password
-if bashio::config.has_value 'username'; then
-    bashio::config.require.password
-
-    username=$(bashio::config 'username')
-    password=$(bashio::config 'password')
-
-    options+=(--username "${username}")
-    options+=(--password "${password}")
-fi
 
 # Autoplay
 if bashio::config.true 'autoplay'; then


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

This removes the non-functional `username` / `password` login options.

librespot removed password authentication in 0.6.0, after Spotify disabled username/password login on their side. The app bundles librespot 0.8.0, which exits with `Password authentication no longer supported, use OAuth` as soon as a password is passed on the command line. Because the run script required a password whenever a username was set, anyone configuring these options ended up in a crash loop. Our own documentation even showed `username`/`password` in the example configuration, steering users straight into it.

Spotify Connect discovery (zeroconf) is the supported path and already works without credentials (the app's default mode), so the credential options are dropped from the configuration, the run script, and the documentation.

Note: this is a breaking change for any user who currently has `username` / `password` set, but those options were already broken (the app could not start with them configured).

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/