### PR TITLE
Remove username/password from translations

### DIFF
--- a/spotify/translations/en.yaml
+++ b/spotify/translations/en.yaml
@@ -18,15 +18,6 @@ configuration:
     name: Initial Volume
     description: >-
       Initial volume in % from 0-100.
-  username:
-    name: Spotify username
-    description: >-
-      An optional username that you use to log in to your Spotify Premium
-      account. This can be helpful when experiencing discovery issues.
-  password:
-    name: Spotify password
-    description: >-
-      The password to log into your Spotify Premium account with.
   autoplay:
     name: Autoplay
     description: >-

--- a/spotify/translations/hu.yaml
+++ b/spotify/translations/hu.yaml
@@ -18,13 +18,3 @@ configuration:
     name: Kezdeti térfogat
     description: >-
       Kezdeti térfogat %-ban 0-100 között.
-  username:
-    name: Spotify felhasználónév
-    description: >-
-      Spotify Premium előfizetéssel rendelkező fiók felhasználóneve.
-      Ez akkor lehet hasznos, ha a Spotify alkalmazás nem találja
-      ezt a kiegészítőt. (Opcionális)
-  password:
-    name: Spotify jelszó
-    description: >-
-      Spotify Premium előfizetéssel rendelkező fiók jelszava.

--- a/spotify/translations/it.yaml
+++ b/spotify/translations/it.yaml
@@ -18,12 +18,3 @@ configuration:
     name: Volume Iniziale
     description: >-
       Volume iniziale in % da 0 a 100.
-  username:
-    name: Spotify username
-    description: >-
-      Uno username opzionale che puoi usare per accedere al tuo account Spotify Premium.
-      Puó essere utile se hai problemi con l'auto discovery.
-  password:
-    name: Spotify password
-    description: >-
-      La password per accedere al tuo account Spotify Premium.


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

Follow-up to #364. That PR removed the non-functional `username` / `password` options from the configuration, run script and documentation, but the matching translation strings were left behind in the `en`, `hu` and `it` translation files.

This removes those now-orphaned `username` / `password` entries so the translations match the actual configuration options again.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Follow-up to #364.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
