### PR TITLE
Improve documentation

### DIFF
--- a/spotify/.README.j2
+++ b/spotify/.README.j2
@@ -2,8 +2,6 @@
 
 [![Release][release-shield]][release] ![Project Stage][project-stage-shield] ![Project Maintenance][maintenance-shield]
 
-[![Discord][discord-shield]][discord] [![Community Forum][forum-shield]][forum]
-
 [![Sponsor Frenck via GitHub Sponsors][github-sponsors-shield]][github-sponsors]
 
 [![Support Frenck on Patreon][patreon-shield]][patreon]
@@ -62,10 +60,6 @@ If you are more interested in stable releases of our apps:
 <https://github.com/hassio-addons/repository>
 
 {% endif %}
-[discord-shield]: https://img.shields.io/discord/478094546522079232.svg
-[discord]: https://discord.me/hassioaddons
-[forum-shield]: https://img.shields.io/badge/community-forum-brightgreen.svg
-[forum]: https://community.home-assistant.io/t/home-assistant-community-add-on-spotify-connect/61210?u=frenck
 [github-sponsors-shield]: https://frenck.dev/wp-content/uploads/2019/12/github_sponsor.png
 [github-sponsors]: https://github.com/sponsors/frenck
 [maintenance-shield]: https://img.shields.io/maintenance/yes/2026.svg

--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -22,7 +22,7 @@ comparison to installing any other Home Assistant app.
 1. Click the "Install" button to install the app.
 1. Select your audio output device and hit `Save` on that as well.
 1. Start the "Spotify Connect" app.
-1. Check the logs of the "Spotify Connect" to see if everything went well.
+1. Check the logs of the "Spotify Connect" app to see if everything went well.
 1. Ready to go!
 
 ## Configuration
@@ -33,7 +33,7 @@ Example app configuration:
 
 ```yaml
 log_level: info
-name: HomeAssistant
+name: Home Assistant
 bitrate: 320
 initial_volume: 50
 autoplay: true
@@ -59,8 +59,8 @@ more severe level, e.g., `debug` also shows `info` messages. By default,
 the `log_level` is set to `info`, which is the recommended setting unless
 you are troubleshooting.
 
-Setting the `log_level` to `debug` will also turn on debug mode on the
-Spotify service.
+Setting the `log_level` to `debug` will also turn on debug mode on
+librespot.
 
 ### Option: `name`
 
@@ -78,8 +78,6 @@ Valid values: `96`, `160` (default) or `320`.
 
 Initial volume in % from 0-100. This setting takes effect when the app starts or
 recovers from a crash.
-
-initial_volume: 50 # Optional
 
 ### Option: `autoplay`
 
@@ -158,4 +156,4 @@ SOFTWARE.
 [issue]: https://github.com/hassio-addons/app-spotify-connect/issues
 [reddit]: https://reddit.com/r/homeassistant
 [releases]: https://github.com/hassio-addons/app-spotify-connect/releases
-[semver]: http://semver.org/spec/v2.0.0.htm
+[semver]: https://semver.org/spec/v2.0.0.html


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

A few documentation improvements across `DOCS.md` and the in-supervisor README template.

`DOCS.md`:

- Fix the broken SemVer link. It pointed at `http://semver.org/spec/v2.0.0.htm`, a truncated URL (`.htm`) over plain `http`; it now points at `https://semver.org/spec/v2.0.0.html`.
- Remove a stray `initial_volume: 50 # Optional` line that sat outside any code block and rendered as loose text in the middle of the option description. The description above it already covers the range and that it is optional.
- Reword the `log_level` note to refer to `librespot` instead of the vague "Spotify service", matching the binary that actually runs.
- Align the example device name with the configuration default (`Home Assistant`).
- Add a missing word in the installation steps ("logs of the "Spotify Connect" app").

`.README.j2`:

- Drop the Discord and Community Forum badges so the in-supervisor README template matches the repository `README.md`, where those badges were already removed.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions and configuration examples
  * Improved debug logging references for clarity
  * Updated security links to HTTPS

* **Style**
  * Removed Discord and Community Forum badges from project header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->