### PR TITLE
Fix misleading librespot shutdown log message

### DIFF
--- a/spotify/rootfs/etc/services.d/librespot/finish
+++ b/spotify/rootfs/etc/services.d/librespot/finish
@@ -8,4 +8,4 @@ if [[ "${1}" -ne 0 ]] && [[ "${1}" -ne 256 ]]; then
   /run/s6/basedir/bin/halt
 fi
 
-bashio::log.info "librespot stopped, restarting..."
+bashio::log.info "librespot stopped."


### PR DESCRIPTION
# Proposed Changes

> (Describe the changes and rationale behind them)

The `finish` script logged `librespot stopped, restarting...` on every exit of the service. That message is misleading:

- On a deliberate stop or restart of the app, the service is not restarted by this script, so "restarting..." is wrong.
- On a crash, the check just above this line halts the app, so it does not restart either.

It now logs a plain `librespot stopped.`, which simply confirms what happened.

This revives the change from #232 (by @LenzGr) on top of the current code. That PR could not be merged as-is because the service has since been renamed from `spotifyd` to `librespot`, so the original message also no longer matched; the wording is applied to the current file here.

## Related Issues

> ([Github link][autolink-references] to related issues or pull requests)

Fixes #231. Supersedes #232.

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
