### PR TITLE
Add access_token option

### DIFF
--- a/spotify/DOCS.md
+++ b/spotify/DOCS.md
@@ -83,6 +83,15 @@ recovers from a crash.
 
 Whether Spotify should autoplay similar songs when reaching the end of the queue.
 
+### Option: `access_token`
+
+When set, login to spotify account using this token. See
+[librespot documentation](https://github.com/librespot-org/librespot/wiki/Options#access-token)
+how to obtain one.
+
+To change the token, set it to empty first, restart app and only then set the
+new one.
+
 ## Known issues and limitations
 
 - This app requires a Spotify Premium account.

--- a/spotify/config.yaml
+++ b/spotify/config.yaml
@@ -15,9 +15,11 @@ options:
   bitrate: 160
   initial_volume: 50
   autoplay: true
+  access_token: ""
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)?
   name: str
   bitrate: list(96|160|320)
   autoplay: bool
   initial_volume: match(^([0-9]|[1-9][0-9]|100)$)?
+  access_token: str

--- a/spotify/rootfs/etc/services.d/librespot/run
+++ b/spotify/rootfs/etc/services.d/librespot/run
@@ -27,6 +27,21 @@ if bashio::config.true 'autoplay'; then
   options+=(--autoplay on)
 fi
 
+# Authentication
+mkdir -m 0700 -p "/data/system-cache"
+options+=(--system-cache "/data/system-cache")
+
+# Token is short-lived, but it's needed only once to generate credentials.json
+# add it only if there is no credentials.json
+if ! [ -e /data/system-cache/credentials.json ] && bashio::config.has_value 'access_token'; then
+  options+=(--access-token "$(bashio::config 'access_token')")
+fi
+
+# Make it possible to invalidate cached credentials
+if [ -e /data/system-cache/credentials.json ] && bashio::config.is_empty 'access_token'; then
+  rm -f /data/system-cache/credentials.json
+fi
+
 # Save writes
 options+=(--disable-audio-cache)
 


### PR DESCRIPTION
# Proposed Changes

This allows logging into specific spotify account. Since the token needs to be set on the cmdline only once (to generate credentials.json), switching to another account is a bit awkward - it requires removing old credentials.json (by setting token to empty) and only then setting new one.
With this, I can successfully use Spotify Premium account again.

## Related Issues

Fixes #369

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added access token configuration option for direct Spotify account authentication
  * Implemented credential caching to streamline authentication after initial setup
  * Added token refresh capability via configuration reset and app restart

* **Documentation**
  * Updated documentation with configuration and update instructions for the access token

<!-- end of auto-generated comment: release notes by coderabbit.ai -->